### PR TITLE
Автоматический запуск авторизации при нехватке прав

### DIFF
--- a/table/appsscript.json
+++ b/table/appsscript.json
@@ -9,6 +9,7 @@
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/script.scriptapp"
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/userinfo.email"
   ]
 }

--- a/table/client/Menu.gs
+++ b/table/client/Menu.gs
@@ -101,6 +101,15 @@ function onOpen() {
   
   // Получаем версию для отображения в меню
   var versionInfo = getVersionDisplayInfo();
+
+  // Ненавязчивое уведомление, если требуется авторизация email-скоупа
+  try {
+    if (typeof maybeNotifyAuthorizationNeeded === 'function') {
+      maybeNotifyAuthorizationNeeded();
+    }
+  } catch (e) {
+    // no-op
+  }
   
   // АВТОМАТИЧЕСКИ СОЗДАЁМ КНОПКИ
   try {
@@ -148,6 +157,7 @@ function onOpen() {
       .addSeparator()
       .addItem('❓ Что это?', 'showCollectConfigHelp'))
     .addSubMenu(ui.createMenu('⚙️ Настройки')
+      .addItem('🔑 Авторизоваться', 'authorizeAccess')
       .addItem('🌟 НАСТРОИТЬ ВСЕ КЛЮЧИ', 'setupAllCredentialsWithHelp')
       .addItem('📊 Проверить статус системы', 'checkSystemStatus')
       .addItem('📋 Очистить ячейки', 'clearChainForA3'))

--- a/table/shared/AuthHelper.gs
+++ b/table/shared/AuthHelper.gs
@@ -1,0 +1,60 @@
+/**
+ * 🚪 Authorization Helper: triggers consent for required scopes
+ * Adds user-friendly prompts to authorize when needed.
+ */
+
+/**
+ * Triggers a lightweight call that requires userinfo.email scope,
+ * which forces the Apps Script consent screen when missing.
+ */
+function authorizeAccess() {
+  try {
+    // This call requires https://www.googleapis.com/auth/userinfo.email
+    var email = Session.getActiveUser().getEmail();
+    var masked = (typeof maskEmail === 'function') ? maskEmail(email) : (email || 'unknown');
+    addSystemLog('Authorization check passed for ' + masked, 'INFO', 'AUTH');
+    SpreadsheetApp.getUi().alert('✅ Доступ уже авторизован. Пользователь: ' + (email || 'unknown'));
+  } catch (e) {
+    // First run will open consent when executed from UI menu
+    addSystemLog('Triggering authorization consent: ' + e.message, 'INFO', 'AUTH');
+    SpreadsheetApp.getUi().alert(
+      '🔑 Требуется авторизация доступа (email).\n\n' +
+      'Пожалуйста, подтвердите разрешения в открывшемся окне и повторите действие.'
+    );
+    // Attempt a second call post-consent (no-op if still unauthorized)
+    try { Session.getActiveUser().getEmail(); } catch (_ignored) {}
+  }
+}
+
+/**
+ * Shows a non-blocking tip if email scope seems missing.
+ * Safe to call from onOpen().
+ */
+function maybeNotifyAuthorizationNeeded(optionalError) {
+  try {
+    var email = Session.getActiveUser().getEmail();
+    if (!email) {
+      SpreadsheetApp.getUi().alert(
+        'ℹ️ Требуется авторизация',
+        'Некоторые функции требуют разрешения на чтение вашего email. ' +
+        'Откройте: 🤖 Table AI → ⚙️ Настройки → "🔑 Авторизоваться"',
+        SpreadsheetApp.getUi().ButtonSet.OK
+      );
+    }
+  } catch (e) {
+    // Only notify once per session using Cache
+    try {
+      var cache = CacheService.getUserCache();
+      var key = 'auth_tip_shown';
+      if (!cache.get(key)) {
+        cache.put(key, '1', 3600); // 1h TTL
+        SpreadsheetApp.getUi().alert(
+          'ℹ️ Требуется авторизация',
+          'Ошибка: ' + (optionalError || e.message) + '\n' +
+          'Откройте: 🤖 Table AI → ⚙️ Настройки → "🔑 Авторизоваться"',
+          SpreadsheetApp.getUi().ButtonSet.OK
+        );
+      }
+    } catch (_ignored) {}
+  }
+}

--- a/table/shared/GoogleSheetsLogger.gs
+++ b/table/shared/GoogleSheetsLogger.gs
@@ -317,8 +317,22 @@ function sendAlert(type, message) {
  */
 function getUserEmail_() {
   try {
-    return Session.getActiveUser().getEmail();
+    var email = Session.getActiveUser().getEmail();
+    if (!email) {
+      // Может потребоваться явная авторизация
+      if (typeof authorizeAccess === 'function') {
+        try { authorizeAccess(); } catch (e) {}
+      }
+      return 'unknown';
+    }
+    return email;
   } catch (e) {
+    // Подсказка пользователю через мягкое уведомление
+    try {
+      if (typeof maybeNotifyAuthorizationNeeded === 'function') {
+        maybeNotifyAuthorizationNeeded(e && e.message);
+      }
+    } catch (_ignored) {}
     return 'unknown';
   }
 }

--- a/test-results/structure-analysis.json
+++ b/test-results/structure-analysis.json
@@ -1,34 +1,34 @@
 {
   "analysis": {
     "client": {
-      "files": 19,
-      "functions": 263,
-      "lines": 8217
+      "files": 21,
+      "functions": 186,
+      "lines": 6808
     },
     "server": {
-      "files": 19,
-      "functions": 146,
-      "lines": 5773
+      "files": 22,
+      "functions": 171,
+      "lines": 6325
     },
     "shared": {
-      "files": 7,
-      "functions": 66,
-      "lines": 2426
+      "files": 9,
+      "functions": 71,
+      "lines": 2584
     },
     "tests": {
       "files": 13,
       "functions": 156,
-      "lines": 5439
+      "lines": 5444
     },
     "web": {
-      "files": 2,
-      "functions": 17,
-      "lines": 567
+      "files": 4,
+      "functions": 27,
+      "lines": 991
     }
   },
   "total": {
-    "files": 60,
-    "functions": 648,
-    "lines": 22422
+    "files": 69,
+    "functions": 611,
+    "lines": 22152
   }
 }

--- a/test-results/syntax-report.json
+++ b/test-results/syntax-report.json
@@ -1,7 +1,7 @@
 {
-  "total": 68,
-  "passed": 60,
-  "failed": 8,
+  "total": 69,
+  "passed": 64,
+  "failed": 5,
   "details": [
     {
       "file": "table/client/AutoButton.gs",
@@ -37,10 +37,8 @@
     },
     {
       "file": "table/client/GeminiClient.gs",
-      "status": "FAILED",
-      "errors": [
-        "Несбалансированные круглые скобки: ( (203) vs ) (210)"
-      ]
+      "status": "OK",
+      "functions": 13
     },
     {
       "file": "table/client/LogViewer.gs",
@@ -60,7 +58,7 @@
     {
       "file": "table/client/Menu.gs",
       "status": "OK",
-      "functions": 11
+      "functions": 13
     },
     {
       "file": "table/client/NetworkRetry.gs",
@@ -71,7 +69,7 @@
       "file": "table/client/OcrHelpers.gs",
       "status": "FAILED",
       "errors": [
-        "Несбалансированные круглые скобки: ( (363) vs ) (364)"
+        "Несбалансированные круглые скобки: ( (114) vs ) (115)"
       ]
     },
     {
@@ -88,7 +86,7 @@
       "file": "table/client/SmartRulesProcessor.gs",
       "status": "FAILED",
       "errors": [
-        "Несбалансированные фигурные скобки: { (48) vs } (49)"
+        "Несбалансированные фигурные скобки: { (29) vs } (30)"
       ]
     },
     {
@@ -129,7 +127,7 @@
     {
       "file": "table/server/ConfigurationManager.gs",
       "status": "OK",
-      "functions": 6
+      "functions": 9
     },
     {
       "file": "table/server/ConfigurationPresets.gs",
@@ -183,10 +181,8 @@
     },
     {
       "file": "table/server/SmartChainService.gs",
-      "status": "FAILED",
-      "errors": [
-        "Несбалансированные круглые скобки: ( (164) vs ) (161)"
-      ]
+      "status": "OK",
+      "functions": 9
     },
     {
       "file": "table/server/SocialImportService.gs",
@@ -197,7 +193,7 @@
       "file": "table/server/SourceDetector.gs",
       "status": "FAILED",
       "errors": [
-        "Несбалансированные круглые скобки: ( (63) vs ) (62)"
+        "Несбалансированные круглые скобки: ( (55) vs ) (56)"
       ]
     },
     {
@@ -222,15 +218,18 @@
     },
     {
       "file": "table/server/VkImportService.gs",
-      "status": "FAILED",
-      "errors": [
-        "Несбалансированные круглые скобки: ( (333) vs ) (335)"
-      ]
+      "status": "OK",
+      "functions": 8
     },
     {
       "file": "table/server/VkTokenValidator.gs",
       "status": "OK",
       "functions": 6
+    },
+    {
+      "file": "table/shared/AuthHelper.gs",
+      "status": "OK",
+      "functions": 2
     },
     {
       "file": "table/shared/Constants.gs",


### PR DESCRIPTION
Add `userinfo.email` scope and authorization helpers to automatically prompt for missing permissions when `Session.getActiveUser().getEmail()` is called.

Previously, `Session.getActiveUser().getEmail()` would fail if the `userinfo.email` scope was not granted. This PR adds the scope, introduces a new 'Authorize access' menu item, and integrates automatic prompts to guide the user to grant permissions, improving robustness and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-26fa9bdd-c8b9-473b-bd17-4ade541def92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-26fa9bdd-c8b9-473b-bd17-4ade541def92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

